### PR TITLE
implement params overrides from file

### DIFF
--- a/src/common/act_on.c
+++ b/src/common/act_on.c
@@ -252,13 +252,12 @@ gboolean _cache_update(const gboolean only_visible,
   // if needed, we show the list of cached images in terminal
   if((darktable.unmuted & DT_DEBUG_ACT_ON) == DT_DEBUG_ACT_ON)
   {
-    gchar *tx = dt_util_dstrcat
-      (NULL,
-       "[images to act on] new cache (%s) : ", only_visible ? "visible" : "all");
+    gchar *tx = g_strdup_printf
+      ("[images to act on] new cache (%s) : ", only_visible ? "visible" : "all");
 
     for(GList *ll = l;
         ll;
-        ll = g_list_next(ll)) tx = dt_util_dstrcat(tx, "%d ", GPOINTER_TO_INT(ll->data));
+        ll = g_list_next(ll)) dt_util_str_cat(&tx, "%d ", GPOINTER_TO_INT(ll->data));
     dt_print(DT_DEBUG_ACT_ON, "%s\n", tx);
     g_free(tx);
   }
@@ -382,7 +381,7 @@ gchar *dt_act_on_get_query(const gboolean only_visible)
   gchar *images = NULL;
   for(; l; l = g_list_next(l))
   {
-    images = dt_util_dstrcat(images, "%d,", GPOINTER_TO_INT(l->data));
+    dt_util_str_cat(&images, "%d,", GPOINTER_TO_INT(l->data));
   }
   if(images)
   {

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -210,37 +210,37 @@ static void _dt_collection_set_selq_pre_sort(const dt_collection_t *collection,
   if(collection->params.query_flags & COLLECTION_QUERY_USE_SORT)
   {
     // we always need filename and version : they are fallback orders in any cases
-    fields = dt_util_dstrcat(fields, ", filename, version");
+    dt_util_str_cat(&fields, ", filename, version");
     if(collection->params.sorts[DT_COLLECTION_SORT_GROUP])
-      fields = dt_util_dstrcat(fields, ", group_id");
+      dt_util_str_cat(&fields, ", group_id");
     if(collection->params.sorts[DT_COLLECTION_SORT_PATH])
-      fields = dt_util_dstrcat(fields, ", film_id");
+      dt_util_str_cat(&fields, ", film_id");
     if(collection->params.sorts[DT_COLLECTION_SORT_DATETIME])
-      fields = dt_util_dstrcat(fields, ", datetime_taken");
+      dt_util_str_cat(&fields, ", datetime_taken");
     if(collection->params.sorts[DT_COLLECTION_SORT_IMPORT_TIMESTAMP])
-      fields = dt_util_dstrcat(fields, ", import_timestamp");
+      dt_util_str_cat(&fields, ", import_timestamp");
     if(collection->params.sorts[DT_COLLECTION_SORT_CHANGE_TIMESTAMP])
-      fields = dt_util_dstrcat(fields, ", change_timestamp");
+      dt_util_str_cat(&fields, ", change_timestamp");
     if(collection->params.sorts[DT_COLLECTION_SORT_EXPORT_TIMESTAMP])
-      fields = dt_util_dstrcat(fields, ", export_timestamp");
+      dt_util_str_cat(&fields, ", export_timestamp");
     if(collection->params.sorts[DT_COLLECTION_SORT_PRINT_TIMESTAMP])
-      fields = dt_util_dstrcat(fields, ", print_timestamp");
+      dt_util_str_cat(&fields, ", print_timestamp");
     if(collection->params.sorts[DT_COLLECTION_SORT_ASPECT_RATIO])
-      fields = dt_util_dstrcat(fields, ", aspect_ratio");
+      dt_util_str_cat(&fields, ", aspect_ratio");
     if(collection->params.sorts[DT_COLLECTION_SORT_RATING])
-      fields = dt_util_dstrcat(fields, ", flags");
+      dt_util_str_cat(&fields, ", flags");
     if(collection->params.sorts[DT_COLLECTION_SORT_CUSTOM_ORDER])
     {
       tag_join = (tagid);
-      fields = dt_util_dstrcat(fields,
-                               ", %s position",
-                               tagid ? "CASE WHEN ti.position IS NULL THEN 0 ELSE ti.position END AS" : "");
+      dt_util_str_cat(&fields,
+                      ", %s position",
+                      tagid ? "CASE WHEN ti.position IS NULL THEN 0 ELSE ti.position END AS" : "");
     }
   }
 
   // clang-format off
-  *selq_pre = dt_util_dstrcat
-    (*selq_pre,
+  dt_util_str_cat
+    (selq_pre,
      "SELECT DISTINCT sel.id"
      "  FROM (SELECT %s"
      "        FROM main.images AS mi"
@@ -271,15 +271,15 @@ int dt_collection_update(const dt_collection_t *collection)
                           and_operator(&and_term), collection->params.film_id);
   }
   // DON'T SELECT IMAGES MARKED TO BE DELETED.
-  wq = dt_util_dstrcat(wq, " %s (flags & %d) != %d",
-                        and_operator(&and_term), DT_IMAGE_REMOVE,
-                        DT_IMAGE_REMOVE);
+  dt_util_str_cat(&wq, " %s (flags & %d) != %d",
+                  and_operator(&and_term), DT_IMAGE_REMOVE,
+                  DT_IMAGE_REMOVE);
 
   /* add where ext if wanted */
   if((collection->params.query_flags & COLLECTION_QUERY_USE_WHERE_EXT))
   {
     gchar *where_ext = dt_collection_get_extended_where(collection, -1);
-    wq = dt_util_dstrcat(wq, " %s %s", and_operator(&and_term), where_ext);
+    dt_util_str_cat(&wq, " %s %s", and_operator(&and_term), where_ext);
     g_free(where_ext);
   }
 
@@ -290,8 +290,8 @@ int dt_collection_update(const dt_collection_t *collection)
   {
     // clang-format off
     /* Show the expanded group... */
-    wq = dt_util_dstrcat
-      (wq,
+    dt_util_str_cat
+      (&wq,
        " AND (group_id = %d OR "
        /* ...and, in unexpanded groups, show the representative image.
         * It's possible that the above WHERE clauses will filter out the representative
@@ -310,7 +310,7 @@ int dt_collection_update(const dt_collection_t *collection)
      * representative image wasn't filtered out.  This is important,
      * because otherwise it may be impossible to collapse the group
      * again. */
-    wq = dt_util_dstrcat(wq, " OR (mi.id = %d)", darktable.gui->expanded_group_id);
+    dt_util_str_cat(&wq, " OR (mi.id = %d)", darktable.gui->expanded_group_id);
   }
 
   // get all the sort items
@@ -338,28 +338,28 @@ int dt_collection_update(const dt_collection_t *collection)
     // some sort orders require to join tables to the query
     if(collection->params.sorts[DT_COLLECTION_SORT_COLOR])
     {
-      selq_post = dt_util_dstrcat
-        (selq_post, " LEFT OUTER JOIN main.color_labels AS b ON sel.id = b.imgid");
+      dt_util_str_cat
+        (&selq_post, " LEFT OUTER JOIN main.color_labels AS b ON sel.id = b.imgid");
     }
     if(collection->params.sorts[DT_COLLECTION_SORT_PATH])
     {
       // clang-format off
-      selq_post = dt_util_dstrcat
-        (selq_post, " JOIN (SELECT id AS film_rolls_id, folder"
+      dt_util_str_cat
+        (&selq_post, " JOIN (SELECT id AS film_rolls_id, folder"
                "       FROM main.film_rolls) ON film_id = film_rolls_id");
       // clang-format on
     }
     if(collection->params.sorts[DT_COLLECTION_SORT_TITLE])
     {
-      selq_post = dt_util_dstrcat
-        (selq_post,
+      dt_util_str_cat
+        (&selq_post,
         " LEFT OUTER JOIN main.meta_data AS mt ON sel.id = mt.id AND mt.key = %d",
         DT_METADATA_XMP_DC_TITLE);
     }
     if(collection->params.sorts[DT_COLLECTION_SORT_DESCRIPTION])
     {
-      selq_post = dt_util_dstrcat
-        (selq_post,
+      dt_util_str_cat
+        (&selq_post,
         " LEFT OUTER JOIN main.meta_data AS md ON sel.id = md.id AND md.key = %d",
         DT_METADATA_XMP_DC_DESCRIPTION);
     }
@@ -372,16 +372,14 @@ int dt_collection_update(const dt_collection_t *collection)
   }
 
   /* store the new query */
-  query
-      = dt_util_dstrcat(query, "%s%s%s %s%s",
-                        selq_pre, wq, selq_post, sq ? sq : "",
-                        (collection->params.query_flags & COLLECTION_QUERY_USE_LIMIT)
-                        ? " " LIMIT_QUERY : "");
-  query_no_group
-      = dt_util_dstrcat(query_no_group, "%s%s%s %s%s",
-                        selq_pre, wq_no_group, selq_post, sq ? sq : "",
-                        (collection->params.query_flags & COLLECTION_QUERY_USE_LIMIT)
-                        ? " " LIMIT_QUERY : "");
+  dt_util_str_cat(&query, "%s%s%s %s%s",
+                  selq_pre, wq, selq_post, sq ? sq : "",
+                  (collection->params.query_flags & COLLECTION_QUERY_USE_LIMIT)
+                  ? " " LIMIT_QUERY : "");
+  dt_util_str_cat(&query_no_group, "%s%s%s %s%s",
+                  selq_pre, wq_no_group, selq_post, sq ? sq : "",
+                  (collection->params.query_flags & COLLECTION_QUERY_USE_LIMIT)
+                  ? " " LIMIT_QUERY : "");
   result = _dt_collection_store(collection, query, query_no_group);
 
   /* free memory used */
@@ -483,9 +481,9 @@ gchar *dt_collection_get_extended_where(const dt_collection_t *collection,
     {
       // exclude the one rule from extended where
       if(i != exclude || mode == 1)
-        complete_string = dt_util_dstrcat(complete_string, "%s", collection->where_ext[i]);
+        dt_util_str_cat(&complete_string, "%s", collection->where_ext[i]);
       else if(i == 0 && g_strcmp0(collection->where_ext[i], ""))
-        complete_string = dt_util_dstrcat(complete_string, "1=1");
+        dt_util_str_cat(&complete_string, "1=1");
     }
   }
   else
@@ -501,10 +499,10 @@ gchar *dt_collection_get_extended_where(const dt_collection_t *collection,
         i < nb_rules && collection->where_ext[i] != NULL;
         i++)
     {
-      rules_txt = dt_util_dstrcat(rules_txt, "%s", collection->where_ext[i]);
+      dt_util_str_cat(&rules_txt, "%s", collection->where_ext[i]);
     }
     if(g_strcmp0(rules_txt, ""))
-      complete_string = dt_util_dstrcat(complete_string, "(%s)", rules_txt);
+      dt_util_str_cat(&complete_string, "(%s)", rules_txt);
 
     g_free(rules_txt);
 
@@ -517,20 +515,20 @@ gchar *dt_collection_get_extended_where(const dt_collection_t *collection,
         i < nb_filters && collection->where_ext[i + nb_rules] != NULL;
         i++)
     {
-      rules_txt = dt_util_dstrcat(rules_txt, "%s", collection->where_ext[i + nb_rules]);
+      dt_util_str_cat(&rules_txt, "%s", collection->where_ext[i + nb_rules]);
     }
 
     if(g_strcmp0(rules_txt, ""))
     {
       if(g_strcmp0(complete_string, ""))
-        complete_string = dt_util_dstrcat(complete_string, " AND ");
-      complete_string = dt_util_dstrcat(complete_string, "(%s)", rules_txt);
+        dt_util_str_cat(&complete_string, " AND ");
+      dt_util_str_cat(&complete_string, "(%s)", rules_txt);
     }
     g_free(rules_txt);
   }
 
   if(!g_strcmp0(complete_string, ""))
-    complete_string = dt_util_dstrcat(complete_string, "1=1");
+    dt_util_str_cat(&complete_string, "1=1");
 
   gchar *where_ext = g_strdup_printf("(%s)", complete_string);
   g_free(complete_string);
@@ -818,7 +816,7 @@ gchar *dt_collection_get_sort_query(const dt_collection_t *collection)
 
     // get the sort query
     gchar *sq = _dt_collection_get_sort_text(sort, sortorder);
-    query = dt_util_dstrcat(query, "%s %s", (i == 0) ? "" : ",", sq);
+    dt_util_str_cat(&query, "%s %s", (i == 0) ? "" : ",", sq);
     g_free(sq);
 
     // set the "already done" values
@@ -834,7 +832,7 @@ gchar *dt_collection_get_sort_query(const dt_collection_t *collection)
   if(!already_last_sort)
   {
     gchar *lsq = _dt_collection_get_sort_text(lastsort, lastsortorder);
-    query = dt_util_dstrcat(query, ", %s", lsq);
+    dt_util_str_cat(&query, ", %s", lsq);
     g_free(lsq);
     if(lastsort == DT_COLLECTION_SORT_FILENAME)
       filename = TRUE;
@@ -842,10 +840,10 @@ gchar *dt_collection_get_sort_query(const dt_collection_t *collection)
 
   // complete the query with fallback if needed
   if(!filename)
-    query = dt_util_dstrcat(query, ", filename%s",
+    dt_util_str_cat(&query, ", filename%s",
                             (first_order) ? " DESC" : "");
 
-  query = dt_util_dstrcat(query, ", version ASC");
+  dt_util_str_cat(&query, ", version ASC");
 
   return query;
 }
@@ -1171,7 +1169,7 @@ void dt_collection_split_operator_datetime(const gchar *input,
 
     if(strcmp(*operator, "") == 0 || strcmp(*operator, "=") == 0 || strcmp(*operator, "<>") == 0)
     {
-      *number1 = dt_util_dstrcat(*number1, "%s%%", txt);
+      dt_util_str_cat(&*number1, "%s%%", txt);
       *number2 = _dt_collection_compute_datetime(">", txt);
     }
     else
@@ -1619,24 +1617,24 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
         if(!g_strcmp0(elems[i], _("unnamed")))
         {
           // clang-format off
-          query = dt_util_dstrcat(query, "%scamera_id IN (SELECT id"
-                                         "                FROM main.cameras"
-                                         "                WHERE (maker IS NULL AND model IS NULL)"
-                                         "                   OR (TRIM(maker)='' AND TRIM(model)=''))",
-                                         i>0?" OR ":"");
+          dt_util_str_cat(&query, "%scamera_id IN (SELECT id"
+                                  "                FROM main.cameras"
+                                  "                WHERE (maker IS NULL AND model IS NULL)"
+                                  "                   OR (TRIM(maker)='' AND TRIM(model)=''))",
+                                  i>0?" OR ":"");
           // clang-format on
         }
         else
         {
           gchar *cam = _add_wildcards(elems[i]);
-          query = dt_util_dstrcat(query,
-                                  "%scamera_id IN (SELECT id FROM main.cameras WHERE maker || ' ' || model LIKE '%s')",
-                                  i>0?" OR ":"", cam);
+          dt_util_str_cat(&query,
+                          "%scamera_id IN (SELECT id FROM main.cameras WHERE maker || ' ' || model LIKE '%s')",
+                          i>0?" OR ":"", cam);
           g_free(cam);
         }
       }
       g_strfreev(elems);
-      query = dt_util_dstrcat(query, ")");
+      dt_util_str_cat(&query, ")");
       break;
 
     case DT_COLLECTION_PROP_TAG: // tag
@@ -1730,23 +1728,23 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       {
         if(!g_strcmp0(elems[i], _("unnamed")))
         {
-          query = dt_util_dstrcat
-            (query,
+          dt_util_str_cat
+            (&query,
              "%slens_id IN (SELECT id FROM main.lens WHERE name IS NULL OR TRIM(name)='' OR UPPER(TRIM(name))='N/A')",
              i>0?" OR ":"");
         }
         else
         {
           gchar *lens = _add_wildcards(elems[i]);
-          query = dt_util_dstrcat(query,
-                                  "%slens_id IN (SELECT id FROM main.lens WHERE name LIKE '%s')",
-                                  i>0?" OR ":"", lens);
+          dt_util_str_cat(&query,
+                          "%slens_id IN (SELECT id FROM main.lens WHERE name LIKE '%s')",
+                          i>0?" OR ":"", lens);
           g_free(lens);
         }
 
       }
       g_strfreev(elems);
-      query = dt_util_dstrcat(query, ")");
+      dt_util_str_cat(&query, ")");
       break;
 
     case DT_COLLECTION_PROP_WHITEBALANCE: // white balance
@@ -1757,23 +1755,23 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       {
         if(!g_strcmp0(elems[i], _("unnamed")))
         {
-          query = dt_util_dstrcat
-            (query,
+          dt_util_str_cat
+            (&query,
              "%swhitebalance_id IN (SELECT id FROM main.whitebalance WHERE name IS NULL OR TRIM(name)='')",
              i>0?" OR ":"");
         }
         else
         {
           gchar *whitebalance = _add_wildcards(elems[i]);
-          query = dt_util_dstrcat(query,
-                                  "%swhitebalance_id IN (SELECT id FROM main.whitebalance WHERE name LIKE '%s')",
-                                  i>0?" OR ":"", whitebalance);
+          dt_util_str_cat(&query,
+                          "%swhitebalance_id IN (SELECT id FROM main.whitebalance WHERE name LIKE '%s')",
+                          i>0?" OR ":"", whitebalance);
           g_free(whitebalance);
         }
 
       }
       g_strfreev(elems);
-      query = dt_util_dstrcat(query, ")");
+      dt_util_str_cat(&query, ")");
       break;
 
     case DT_COLLECTION_PROP_FLASH: // flash
@@ -1784,22 +1782,22 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       {
         if(!g_strcmp0(elems[i], _("unnamed")))
         {
-          query = dt_util_dstrcat
-            (query,
+          dt_util_str_cat
+            (&query,
              "%sflash_id IN (SELECT id FROM main.flash WHERE name IS NULL OR TRIM(name)='')",
              i>0?" OR ":"");
         }
         else
         {
           gchar *flash = _add_wildcards(elems[i]);
-          query = dt_util_dstrcat(query,
-                                  "%sflash_id IN (SELECT id FROM main.flash WHERE name LIKE '%s')",
-                                  i>0?" OR ":"", flash);
+          dt_util_str_cat(&query,
+                          "%sflash_id IN (SELECT id FROM main.flash WHERE name LIKE '%s')",
+                          i>0?" OR ":"", flash);
           g_free(flash);
         }
       }
       g_strfreev(elems);
-      query = dt_util_dstrcat(query, ")");
+      dt_util_str_cat(&query, ")");
       break;
 
     case DT_COLLECTION_PROP_EXPOSURE_PROGRAM: // exposure program
@@ -1810,22 +1808,22 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       {
         if(!g_strcmp0(elems[i], _("unnamed")))
         {
-          query = dt_util_dstrcat
-            (query,
+          dt_util_str_cat
+            (&query,
              "%sexposure_program_id IN (SELECT id FROM main.exposure_program WHERE name IS NULL OR TRIM(name)='')",
              i>0?" OR ":"");
         }
         else
         {
           gchar *exposure_program = _add_wildcards(elems[i]);
-          query = dt_util_dstrcat(query,
-                                  "%sexposure_program_id IN (SELECT id FROM main.exposure_program WHERE name LIKE '%s')",
-                                  i>0?" OR ":"", exposure_program);
+          dt_util_str_cat(&query,
+                          "%sexposure_program_id IN (SELECT id FROM main.exposure_program WHERE name LIKE '%s')",
+                          i>0?" OR ":"", exposure_program);
           g_free(exposure_program);
         }
       }
       g_strfreev(elems);
-      query = dt_util_dstrcat(query, ")");
+      dt_util_str_cat(&query, ")");
       break;
 
     case DT_COLLECTION_PROP_METERING_MODE: // metering mode
@@ -1836,22 +1834,22 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       {
         if(!g_strcmp0(elems[i], _("unnamed")))
         {
-          query = dt_util_dstrcat
-            (query,
+          dt_util_str_cat
+            (&query,
              "%smetering_mode_id IN (SELECT id FROM main.metering_mode WHERE name IS NULL OR TRIM(name)='')",
              i>0?" OR ":"");
         }
         else
         {
           gchar *metering_mode = _add_wildcards(elems[i]);
-          query = dt_util_dstrcat(query,
-                                  "%smetering_mode_id IN (SELECT id FROM main.metering_mode WHERE name LIKE '%s')",
-                                  i>0?" OR ":"", metering_mode);
+          dt_util_str_cat(&query,
+                          "%smetering_mode_id IN (SELECT id FROM main.metering_mode WHERE name LIKE '%s')",
+                          i>0?" OR ":"", metering_mode);
           g_free(metering_mode);
         }
       }
       g_strfreev(elems);
-      query = dt_util_dstrcat(query, ")");
+      dt_util_str_cat(&query, ")");
       break;
 
     case DT_COLLECTION_PROP_GROUP_ID: // group id
@@ -1861,13 +1859,13 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       for(int i = 0; i < g_strv_length(elems); i++)
       {
         gchar *group_ids = _add_wildcards(elems[i]);
-        query = dt_util_dstrcat(query,
-                                "%sgroup_id LIKE '%s'",
-                                i>0?" OR ":"", group_ids);
+        dt_util_str_cat(&query,
+                        "%sgroup_id LIKE '%s'",
+                        i>0?" OR ":"", group_ids);
         g_free(group_ids);
       }
       g_strfreev(elems);
-      query = dt_util_dstrcat(query, ")");
+      dt_util_str_cat(&query, ")");
       break;
 
     case DT_COLLECTION_PROP_FOCAL_LENGTH: // focal length
@@ -2530,9 +2528,9 @@ void dt_collection_update_query(const dt_collection_t *collection,
       {
         const int id = GPOINTER_TO_INT(l->data);
         if(i == 0)
-          txt = dt_util_dstrcat(txt, "%d", id);
+          dt_util_str_cat(&txt, "%d", id);
         else
-          txt = dt_util_dstrcat(txt, ",%d", id);
+          dt_util_str_cat(&txt, ",%d", id);
         i++;
       }
       // 2. search the first imgid not in the list but AFTER the list

--- a/src/common/color_vocabulary.c
+++ b/src/common/color_vocabulary.c
@@ -199,7 +199,7 @@ const char *Lch_to_color_name(dt_aligned_pixel_t color)
   // Write all matching ethnicities
   for(int elem = 0; elem < ETHNIE_END; ++elem)
     if(matches[elem])
-      out = dt_util_dstrcat(out, _("average %s skin tone\n"), ethnies[elem].name);
+      dt_util_str_cat(&out, _("average %s skin tone\n"), ethnies[elem].name);
 
   if(is_skin) return out;
 

--- a/src/common/colorlabels.c
+++ b/src/common/colorlabels.c
@@ -339,11 +339,11 @@ static float _action_process_color_label(gpointer target,
         for(GList *res_iter = res; res_iter; res_iter = g_list_next(res_iter))
         {
           const GdkRGBA c = darktable.bauhaus->colorlabels[GPOINTER_TO_INT(res_iter->data)];
-          result = dt_util_dstrcat(result,
-                                  "<span foreground='#%02x%02x%02x'>⬤ </span>",
-                                  (guint)(c.red*255),
-                                   (guint)(c.green*255),
-                                   (guint)(c.blue*255));
+          dt_util_str_cat(&result,
+                          "<span foreground='#%02x%02x%02x'>⬤ </span>",
+                          (guint)(c.red*255),
+                          (guint)(c.green*255),
+                          (guint)(c.blue*255));
         }
         g_list_free(res);
         if(result)

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -179,7 +179,7 @@ static void _get_xmp_tags(const char *prefix,
   {
     for(int i = 0; pl[i].name_ != 0; ++i)
     {
-      char *tag = dt_util_dstrcat(NULL, "Xmp.%s.%s,%s",
+      char *tag = g_strdup_printf("Xmp.%s.%s,%s",
                                   prefix, pl[i].name_, _get_exiv2_type(pl[i].typeId_));
       *taglist = g_list_prepend(*taglist, tag);
     }
@@ -251,7 +251,7 @@ void dt_exif_set_exiv2_taglist()
           const Exiv2::TagInfo *tagInfo = groupList->tagList_();
           while(tagInfo->tag_ != 0xFFFF)
           {
-            char *tag = dt_util_dstrcat(NULL, "Exif.%s.%s,%s",
+            char *tag = g_strdup_printf("Exif.%s.%s,%s",
                                         groupList->groupName_,
                                         tagInfo->name_,
                                         _get_exiv2_type(tagInfo->typeId_));
@@ -266,7 +266,7 @@ void dt_exif_set_exiv2_taglist()
     const Exiv2::DataSet *iptcEnvelopeList = Exiv2::IptcDataSets::envelopeRecordList();
     while(iptcEnvelopeList->number_ != 0xFFFF)
     {
-      char *tag = dt_util_dstrcat(NULL, "Iptc.Envelope.%s,%s%s",
+      char *tag = g_strdup_printf("Iptc.Envelope.%s,%s%s",
                                   iptcEnvelopeList->name_,
                                   _get_exiv2_type(iptcEnvelopeList->type_),
                                   iptcEnvelopeList->repeatable_ ? "-R" : "");
@@ -278,7 +278,7 @@ void dt_exif_set_exiv2_taglist()
       Exiv2::IptcDataSets::application2RecordList();
     while(iptcApplication2List->number_ != 0xFFFF)
     {
-      char *tag = dt_util_dstrcat(NULL, "Iptc.Application2.%s,%s%s",
+      char *tag = g_strdup_printf("Iptc.Application2.%s,%s%s",
                                   iptcApplication2List->name_,
                                   _get_exiv2_type(iptcApplication2List->type_),
                                   iptcApplication2List->repeatable_ ? "-R" : "");
@@ -2105,13 +2105,13 @@ void dt_exif_apply_default_metadata(dt_image_t *img)
       if(dt_metadata_get_type(i) != DT_METADATA_TYPE_INTERNAL)
       {
         const char *name = dt_metadata_get_name(i);
-        char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+        char *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
         const gboolean hidden = dt_conf_get_int(setting) & DT_METADATA_FLAG_HIDDEN;
         g_free(setting);
         // don't import hidden stuff
         if(!hidden)
         {
-          setting = dt_util_dstrcat(NULL, "ui_last/import_last_%s", name);
+          setting = g_strdup_printf("ui_last/import_last_%s", name);
           str = dt_conf_get_string(setting);
           if(str && str[0])
           {
@@ -4693,7 +4693,7 @@ static void _set_xmp_dt_metadata(Exiv2::XmpData &xmpData,
        && (dt_metadata_get_type(keyid) != DT_METADATA_TYPE_INTERNAL))
     {
       const gchar *name = dt_metadata_get_name(keyid);
-      gchar *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+      gchar *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
       const uint32_t flag =  dt_conf_get_int(setting);
       g_free(setting);
       if(!(flag & (DT_METADATA_FLAG_PRIVATE | DT_METADATA_FLAG_HIDDEN)))

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -5009,8 +5009,7 @@ char *dt_exif_xmp_read_string(const dt_imgid_t imgid)
   try
   {
     char input_filename[PATH_MAX] = { 0 };
-    gboolean from_cache = FALSE;
-    dt_image_full_path(imgid, input_filename, sizeof(input_filename), &from_cache);
+    dt_image_full_path(imgid, input_filename, sizeof(input_filename), NULL);
 
     // First take over the data from the source image
     Exiv2::XmpData xmpData;

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -785,9 +785,9 @@ static gboolean _history_copy_and_paste_on_image_overwrite(const dt_imgid_t imgi
         if(dt_history_module_skip_copy(module->flags()))
         {
           if(skip_modules)
-            skip_modules = dt_util_dstrcat(skip_modules, ",");
+            dt_util_str_cat(&skip_modules, ",");
 
-          skip_modules = dt_util_dstrcat(skip_modules, "'%s'", module->op);
+          dt_util_str_cat(&skip_modules, "'%s'", module->op);
         }
       }
     }
@@ -1654,15 +1654,15 @@ void dt_history_hash_write_from_history(const dt_imgid_t imgid,
     }
     if(type & DT_HISTORY_HASH_AUTO)
     {
-      fields = dt_util_dstrcat(fields, "%s,", "auto_hash");
-      values = dt_util_dstrcat(values, "?2,");
-      conflict = dt_util_dstrcat(conflict, "auto_hash=?2,");
+      dt_util_str_cat(&fields, "%s,", "auto_hash");
+      dt_util_str_cat(&values, "?2,");
+      dt_util_str_cat(&conflict, "auto_hash=?2,");
     }
     if(type & DT_HISTORY_HASH_CURRENT)
     {
-      fields = dt_util_dstrcat(fields, "%s,", "current_hash");
-      values = dt_util_dstrcat(values, "?2,");
-      conflict = dt_util_dstrcat(conflict, "current_hash=?2,");
+      dt_util_str_cat(&fields, "%s,", "current_hash");
+      dt_util_str_cat(&values, "?2,");
+      dt_util_str_cat(&conflict, "current_hash=?2,");
     }
     // remove the useless last comma
     if(fields) fields[strlen(fields) - 1] = '\0';

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1213,8 +1213,7 @@ static int32_t _image_get_possible_version(const dt_imgid_t imgid,
   char imgpath[PATH_MAX] = { 0 };
   char versionpath[PATH_MAX] = { 0 };
 
-  gboolean from_cache = FALSE;
-  dt_image_full_path(imgid, imgpath, sizeof(imgpath), &from_cache);
+  dt_image_full_path(imgid, imgpath, sizeof(imgpath), NULL);
 
   for(int32_t version = MAX(1, max_version); version < 1000; version++)
   {
@@ -2182,8 +2181,7 @@ int32_t dt_image_rename(const dt_imgid_t imgid, const int32_t filmid, const gcha
   int32_t result = -1;
   gchar oldimg[PATH_MAX] = { 0 };
   gchar newimg[PATH_MAX] = { 0 };
-  gboolean from_cache = FALSE;
-  dt_image_full_path(imgid, oldimg, sizeof(oldimg), &from_cache);
+  dt_image_full_path(imgid, oldimg, sizeof(oldimg), NULL);
   gchar *newdir = NULL;
 
   sqlite3_stmt *film_stmt;
@@ -2387,7 +2385,6 @@ dt_imgid_t dt_image_copy_rename(const dt_imgid_t imgid,
   gchar srcpath[PATH_MAX] = { 0 };
   gchar *newdir = NULL;
   gchar *filename = NULL;
-  gboolean from_cache = FALSE;
   gchar *oldFilename = NULL;
   gchar *newFilename = NULL;
 
@@ -2404,7 +2401,7 @@ dt_imgid_t dt_image_copy_rename(const dt_imgid_t imgid,
   GFile *src = NULL, *dest = NULL;
   if(newdir)
   {
-    dt_image_full_path(imgid, srcpath, sizeof(srcpath), &from_cache);
+    dt_image_full_path(imgid, srcpath, sizeof(srcpath), NULL);
     oldFilename = g_path_get_basename(srcpath);
     gchar *destpath;
     if(newname)
@@ -2684,8 +2681,7 @@ gboolean dt_image_local_copy_set(const dt_imgid_t imgid)
   gchar srcpath[PATH_MAX] = { 0 };
   gchar destpath[PATH_MAX] = { 0 };
 
-  gboolean from_cache = FALSE;
-  dt_image_full_path(imgid, srcpath, sizeof(srcpath), &from_cache);
+  dt_image_full_path(imgid, srcpath, sizeof(srcpath), NULL);
 
   _image_local_copy_full_path(imgid, destpath, sizeof(destpath));
 
@@ -2945,9 +2941,8 @@ void dt_image_local_copy_synch(void)
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     const dt_imgid_t imgid = sqlite3_column_int(stmt, 0);
-    gboolean from_cache = FALSE;
     char filename[PATH_MAX] = { 0 };
-    dt_image_full_path(imgid, filename, sizeof(filename), &from_cache);
+    dt_image_full_path(imgid, filename, sizeof(filename), NULL);
 
     if(g_file_test(filename, G_FILE_TEST_EXISTS))
     {
@@ -3101,9 +3096,8 @@ char *dt_image_get_audio_path_from_path(const char *image_path)
 
 char *dt_image_get_audio_path(const dt_imgid_t imgid)
 {
-  gboolean from_cache = FALSE;
   char image_path[PATH_MAX] = { 0 };
-  dt_image_full_path(imgid, image_path, sizeof(image_path), &from_cache);
+  dt_image_full_path(imgid, image_path, sizeof(image_path), NULL);
 
   return dt_image_get_audio_path_from_path(image_path);
 }
@@ -3133,9 +3127,8 @@ char *dt_image_get_text_path_from_path(const char *image_path)
 
 char *dt_image_get_text_path(const dt_imgid_t imgid)
 {
-  gboolean from_cache = FALSE;
   char image_path[PATH_MAX] = { 0 };
-  dt_image_full_path(imgid, image_path, sizeof(image_path), &from_cache);
+  dt_image_full_path(imgid, image_path, sizeof(image_path), NULL);
 
   return dt_image_get_text_path_from_path(image_path);
 }

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -414,7 +414,7 @@ void dt_image_full_path(const dt_imgid_t imgid,
   }
   sqlite3_finalize(stmt);
 
-  if(*from_cache)
+  if(from_cache && *from_cache)
   {
     char lc_pathname[PATH_MAX] = { 0 };
     _image_local_copy_full_path(imgid, lc_pathname, sizeof(lc_pathname));

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -233,7 +233,7 @@ static gchar *_get_tb_removed_metadata_string_values(GList *before, GList *after
     }
     if(!same_key || different_value || !value[0])
     {
-      metadata_list = dt_util_dstrcat(metadata_list, "%d,", atoi(b->data));
+      dt_util_str_cat(&metadata_list, "%d,", atoi(b->data));
     }
     b = g_list_next(b);
     b = g_list_next(b);
@@ -262,7 +262,7 @@ static gchar *_get_tb_added_metadata_string_values(const int img, GList *before,
     if((!same_key || different_value) && value[0])
     {
       char *escaped_text = sqlite3_mprintf("%q", value);
-      metadata_list = dt_util_dstrcat(metadata_list, "(%d,%d,'%s'),", GPOINTER_TO_INT(img), atoi(a->data), escaped_text);
+      dt_util_str_cat(&metadata_list, "(%d,%d,'%s'),", GPOINTER_TO_INT(img), atoi(a->data), escaped_text);
       sqlite3_free(escaped_text);
     }
     a = g_list_next(a);

--- a/src/common/metadata_export.c
+++ b/src/common/metadata_export.c
@@ -55,7 +55,7 @@ char *dt_lib_export_metadata_get_conf(void)
         {
           formula[0] = '\0';
           formula ++;
-          metadata_presets = dt_util_dstrcat(metadata_presets,"\1%s\1%s", nameformula, formula);
+          dt_util_str_cat(&metadata_presets,"\1%s\1%s", nameformula, formula);
         }
       }
       g_free(nameformula);

--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -481,7 +481,7 @@ void dt_selection_select_list(struct dt_selection_t *selection, GList *list)
       imgid = GPOINTER_TO_INT(list->data);
       count++;
       selection->last_single_id = imgid;
-      query = dt_util_dstrcat(query, ",(%d)", imgid);
+      dt_util_str_cat(&query, ",(%d)", imgid);
       list = g_list_next(list);
     }
     DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), query, NULL, NULL, NULL);

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -45,7 +45,7 @@ static gchar *_get_tb_removed_tag_string_values(GList *before,
   {
     if(!g_list_find(a, b->data))
     {
-      tag_list = dt_util_dstrcat(tag_list, "%d,", GPOINTER_TO_INT(b->data));
+      dt_util_str_cat(&tag_list, "%d,", GPOINTER_TO_INT(b->data));
     }
   }
   if(tag_list) tag_list[strlen(tag_list) - 1] = '\0';
@@ -63,8 +63,8 @@ static gchar *_get_tb_added_tag_string_values(const dt_imgid_t img,
     if(!g_list_find(b, a->data))
     {
       // clang-format off
-      tag_list = dt_util_dstrcat
-        (tag_list,
+      dt_util_str_cat
+        (&tag_list,
          "(%d,%d,"
          "  (SELECT (IFNULL(MAX(position),0) & 0xFFFFFFFF00000000) + (1 << 32)"
          "    FROM main.tagged_images)"
@@ -297,7 +297,7 @@ guint dt_tag_remove_list(GList *tag_list)
   for(GList *taglist = tag_list; taglist ; taglist = g_list_next(taglist))
   {
     const guint tagid = ((dt_tag_t *)taglist->data)->id;
-    flatlist = dt_util_dstrcat(flatlist, "%u,", tagid);
+    dt_util_str_cat(&flatlist, "%u,", tagid);
     count++;
     if(flatlist && count > 1000)
     {
@@ -1121,7 +1121,7 @@ GList *dt_tag_get_images_from_list(const GList *img, const gint tagid)
   char *images = NULL;
   for(GList *imgs = (GList *)img; imgs; imgs = g_list_next(imgs))
   {
-    images = dt_util_dstrcat(images, "%d,",GPOINTER_TO_INT(imgs->data));
+    dt_util_str_cat(&images, "%d,",GPOINTER_TO_INT(imgs->data));
   }
   if(images)
   {
@@ -1488,7 +1488,7 @@ static gchar *dt_cleanup_synonyms(gchar *synonyms_entry)
       char *e = g_strstrip(*entry);
       if(*e)
       {
-        synonyms = dt_util_dstrcat(synonyms, "%s, ", e);
+        dt_util_str_cat(&synonyms, "%s, ", e);
       }
       entry++;
     }
@@ -1572,7 +1572,7 @@ void dt_tag_add_synonym(const gint tagid,
   char *synonyms = dt_tag_get_synonyms(tagid);
   if(synonyms)
   {
-    synonyms = dt_util_dstrcat(synonyms, ", %s", synonym);
+    dt_util_str_cat(&synonyms, ", %s", synonym);
   }
   else
   {
@@ -1872,7 +1872,7 @@ char *dt_tag_get_subtags(const dt_imgid_t imgid,
           valid = FALSE;
       }
       if(valid)
-        tags = dt_util_dstrcat(tags, "%s,", subtag);
+        dt_util_str_cat(&tags, "%s,", subtag);
       g_strfreev(pch);
     }
   }

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -56,28 +56,26 @@
 #include <librsvg/rsvg-cairo.h>
 #endif
 
-gchar *dt_util_dstrcat(gchar *str, const gchar *format, ...)
+void dt_util_str_cat(gchar **str, const gchar *format, ...)
 {
+  if(!str) return;
+
   va_list args;
-  gchar *ns;
   va_start(args, format);
-  const size_t clen = str ? strlen(str) : 0;
+  const size_t clen = *str ? strlen(*str) : 0;
   const int alen = g_vsnprintf(NULL, 0, format, args);
+  va_end(args);
   const int nsize = alen + clen + 1;
 
   /* realloc for new string */
-  ns = g_realloc(str, nsize);
-  if(str == NULL) ns[0] = '\0';
-  va_end(args);
+  *str = g_realloc(*str, nsize);
 
   /* append string */
   va_start(args, format);
-  g_vsnprintf(ns + clen, alen + 1, format, args);
+  g_vsnprintf(*str + clen, alen + 1, format, args);
   va_end(args);
 
-  ns[nsize - 1] = '\0';
-
-  return ns;
+  (*str)[nsize - 1] = '\0';
 }
 
 guint dt_util_str_occurence(const gchar *haystack, const gchar *needle)

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -25,7 +25,7 @@
 G_BEGIN_DECLS
 
 /** dynamically allocate and concatenate string */
-gchar *dt_util_dstrcat(gchar *str, const gchar *format, ...) __attribute__((format(printf, 2, 3)));
+void dt_util_str_cat(gchar **str, const gchar *format, ...) __attribute__((format(printf, 2, 3)));
 
 /** replace all occurrences of pattern by substitute. the returned value has to be freed after use. */
 gchar *dt_util_str_replace(const gchar *string, const gchar *pattern, const gchar *substitute);

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -710,8 +710,8 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
     {
       const int dot_index = GPOINTER_TO_INT(res_iter->data);
       const GdkRGBA c = darktable.bauhaus->colorlabels[dot_index];
-      result = dt_util_dstrcat
-        (result,
+      dt_util_str_cat
+        (&result,
          "<span foreground='#%02x%02x%02x'>⬤ </span>",
          (guint)(c.red*255), (guint)(c.green*255), (guint)(c.blue*255));
     }

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -917,8 +917,7 @@ static int _update_all_thumbs(const dt_mipmap_size_t max_mip)
     const int64_t stamp = MAX(sqlite3_column_int64(stmt, 1), sqlite3_column_int64(stmt, 2));
 
     char path[PATH_MAX] = { 0 };
-    gboolean from_cache = FALSE;
-    dt_image_full_path(imgid, path, sizeof(path), &from_cache);
+    dt_image_full_path(imgid, path, sizeof(path), NULL);
     const gboolean available = dt_util_test_image_file(path);
 
     if(available)

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -875,7 +875,7 @@ static int32_t dt_control_remove_images_job_run(dt_job_t *job)
     }
     else
     {
-      really_removed = dt_util_dstrcat(really_removed, really_removed?",%d":"%d", imgid);
+      dt_util_str_cat(&really_removed, really_removed?",%d":"%d", imgid);
       dt_image_remove(imgid);
     }
     t = g_list_next(t);
@@ -1565,10 +1565,10 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
   if(!g_strstr_len(settings->metadata_export, -1, iptc_envelope_characterset))
   {
     // IPTC character encoding not set by user, so we set the default utf8 here
-    settings->metadata_export = dt_util_dstrcat(settings->metadata_export,
-                                                "\1%s\1%s", 
-                                                iptc_envelope_characterset,
-                                                "\x1b%G");  // ESC % G
+    dt_util_str_cat(&settings->metadata_export,
+                    "\1%s\1%s",
+                    iptc_envelope_characterset,
+                    "\x1b%G");  // ESC % G
   }
 
   dt_export_metadata_t metadata;

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -271,11 +271,10 @@ static int32_t dt_control_write_sidecar_files_job_run(dt_job_t *job)
      &stmt, NULL);
   while(t)
   {
-    gboolean from_cache = FALSE;
     const dt_imgid_t imgid = GPOINTER_TO_INT(t->data);
     const dt_image_t *img = dt_image_cache_get(darktable.image_cache, (int32_t)imgid, 'r');
     char dtfilename[PATH_MAX] = { 0 };
-    dt_image_full_path(img->id, dtfilename, sizeof(dtfilename), &from_cache);
+    dt_image_full_path(img->id, dtfilename, sizeof(dtfilename), NULL);
     dt_image_path_append_version(img->id, dtfilename, sizeof(dtfilename));
     g_strlcat(dtfilename, ".xmp", sizeof(dtfilename));
     if(!dt_exif_xmp_write(imgid, dtfilename))
@@ -1184,8 +1183,7 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
     }
 
     char filename[PATH_MAX] = { 0 };
-    gboolean from_cache = FALSE;
-    dt_image_full_path(imgid, filename, sizeof(filename), &from_cache);
+    dt_image_full_path(imgid, filename, sizeof(filename), NULL);
 
     int duplicates = 0;
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -620,7 +620,7 @@ static void _apply_module_overrides(dt_develop_t *dev,
             for(dt_introspection_type_enum_tuple_t *e = i->Enum.values; e && e->name; e++)
             {
               if(old_value == e->value) item = e->name;
-              list = dt_util_dstrcat(list, "%s%s", *list ? ", " : "", e->name);
+              dt_util_str_cat(&list, "%s%s", *list ? ", " : "", e->name);
               if(assign && (!g_ascii_strcasecmp(value, e->name) ||
                             !g_ascii_strcasecmp(value, e->description)))
                 *(int*)ptr = e->value;
@@ -637,21 +637,21 @@ static void _apply_module_overrides(dt_develop_t *dev,
           default:
             if(!found) continue;
             dt_print(DT_DEBUG_ALWAYS,
-                    "[dt_iop_default_init] in `%s' unsupported introspection"
-                    " type \"%s\" encountered"
-                    " in field '%s'\n",
-                    history->module->op, i->header.type_name, i->header.field_name);
+                     "[dt_iop_default_init] in `%s' unsupported introspection"
+                     " type \"%s\" encountered"
+                     " in field '%s'\n",
+                     history->module->op, i->header.type_name, i->header.field_name);
             break;
           }
 
           if(values)
           {
             gboolean multi = instance || (do_all && *history->multi_name);
-            man = dt_util_dstrcat(man, "%s%s%s/%s=%s%s%s\n",
-                                       history->module->op,
-                                       multi ? "," : "", multi ? history->multi_name : "",
-                                       i->header.field_name,
-                                       values, assign ? " -> " : "", assign ? value : "");
+            dt_util_str_cat(&man, "%s%s%s/%s=%s%s%s\n",
+                                  history->module->op,
+                                  multi ? "," : "", multi ? history->multi_name : "",
+                                  i->header.field_name,
+                                  values, assign ? " -> " : "", assign ? value : "");
             g_free(values);
           }
         }

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3175,7 +3175,7 @@ void dt_iop_set_darktable_iop_table()
   for(GList *iop = darktable.iop; iop; iop = g_list_next(iop))
   {
     dt_iop_module_so_t *module = (dt_iop_module_so_t *)iop->data;
-    module_list = dt_util_dstrcat(module_list, "(\"%s\",\"%s\"),",
+    dt_util_str_cat(&module_list, "(\"%s\",\"%s\"),",
                                   module->op, module->name());
   }
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -242,40 +242,38 @@ void dt_iop_default_init(dt_iop_module_t *module)
 
   while(i->header.type != DT_INTROSPECTION_TYPE_NONE)
   {
+    gpointer ptr = module->default_params + i->header.offset;
     switch(i->header.type)
     {
     case DT_INTROSPECTION_TYPE_FLOATCOMPLEX:
-      *(float complex*)((uint8_t *)module->default_params + i->header.offset) =
-        i->FloatComplex.Default;
+      *(float complex*)ptr = i->FloatComplex.Default;
       break;
     case DT_INTROSPECTION_TYPE_FLOAT:
-      *(float*)((uint8_t *)module->default_params + i->header.offset) = i->Float.Default;
+      *(float*)ptr = i->Float.Default;
       break;
     case DT_INTROSPECTION_TYPE_INT:
-      *(int*)((uint8_t *)module->default_params + i->header.offset) = i->Int.Default;
+      *(int*)ptr = i->Int.Default;
       break;
     case DT_INTROSPECTION_TYPE_UINT:
-      *(unsigned int*)((uint8_t *)module->default_params + i->header.offset) =
-        i->UInt.Default;
+      *(unsigned int*)ptr = i->UInt.Default;
       break;
     case DT_INTROSPECTION_TYPE_USHORT:
-      *(unsigned short*)((uint8_t *)module->default_params + i->header.offset) =
-        i->UShort.Default;
+      *(unsigned short*)ptr = i->UShort.Default;
       break;
     case DT_INTROSPECTION_TYPE_INT8:
-      *(short*)((uint8_t *)module->default_params + i->header.offset) = i->Int8.Default;
+      *(short*)ptr = i->Int8.Default;
       break;
     case DT_INTROSPECTION_TYPE_ENUM:
-      *(int*)((uint8_t *)module->default_params + i->header.offset) = i->Enum.Default;
+      *(int*)ptr = i->Enum.Default;
       break;
     case DT_INTROSPECTION_TYPE_BOOL:
-      *(gboolean*)((uint8_t *)module->default_params + i->header.offset) = i->Bool.Default;
+      *(gboolean*)ptr = i->Bool.Default;
       break;
     case DT_INTROSPECTION_TYPE_CHAR:
-      *(char*)((uint8_t *)module->default_params + i->header.offset) = i->Char.Default;
+      *(char*)ptr = i->Char.Default;
       break;
     case DT_INTROSPECTION_TYPE_OPAQUE:
-      memset((uint8_t *)module->default_params + i->header.offset, 0, i->header.size);
+      memset(ptr, 0, i->header.size);
       break;
     case DT_INTROSPECTION_TYPE_ARRAY:
       {
@@ -284,7 +282,7 @@ void dt_iop_default_init(dt_iop_module_t *module)
         size_t element_size = i->Array.field->header.size;
         if(element_size % sizeof(int))
         {
-          int8_t *p = (int8_t *)module->default_params + i->header.offset;
+          int8_t *p = ptr;
           for(size_t c = element_size; c < i->header.size; c++, p++)
             p[element_size] = *p;
         }
@@ -293,7 +291,7 @@ void dt_iop_default_init(dt_iop_module_t *module)
           element_size /= sizeof(int);
           const size_t num_ints = i->header.size / sizeof(int);
 
-          int *p = (int *)((uint8_t *)module->default_params + i->header.offset);
+          int *p = ptr;
           for(size_t c = element_size; c < num_ints; c++, p++)
             p[element_size] = *p;
         }

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -1110,7 +1110,7 @@ static GtkWidget *_popup_get_numeric_menu(GtkDarktableRangeSelect *range, GtkWid
       continue;
 
     gchar *txt = (blo->txt) ? g_strdup(blo->txt) : range->print(blo->value_r, TRUE);
-    if(blo->nb > 0) txt = dt_util_dstrcat(txt, " (%d)", blo->nb);
+    if(blo->nb > 0) dt_util_str_cat(&txt, " (%d)", blo->nb);
     GtkWidget *smt = gtk_menu_item_new_with_label(txt);
     g_free(txt);
     g_object_set_data(G_OBJECT(smt), "range_block", blo);
@@ -1137,7 +1137,7 @@ static GtkWidget *_popup_get_numeric_menu(GtkDarktableRangeSelect *range, GtkWid
       continue;
 
     gchar *txt = (blo->txt) ? g_strdup(blo->txt) : range->print(blo->value_r, TRUE);
-    if(blo->nb > 0) txt = dt_util_dstrcat(txt, " (%d)", blo->nb);
+    if(blo->nb > 0) dt_util_str_cat(&txt, " (%d)", blo->nb);
     GtkWidget *smt = gtk_menu_item_new_with_label(txt);
     g_free(txt);
     g_object_set_data(G_OBJECT(smt), "range_block", blo);
@@ -1773,19 +1773,19 @@ gchar *dtgtk_range_select_get_bounds_pretty(GtkDarktableRangeSelect *range)
   else
     txt = range->print(range->select_min_r, TRUE);
 
-  txt = dt_util_dstrcat(txt, " → ");
+  dt_util_str_cat(&txt, " → ");
 
   if(range->bounds & DT_RANGE_BOUND_MAX)
-    txt = dt_util_dstrcat(txt, _("max"));
+    dt_util_str_cat(&txt, _("max"));
   else if(range->bounds & DT_RANGE_BOUND_MAX_RELATIVE)
-    txt = dt_util_dstrcat(txt, "+%04d:%02d:%02d %02d:%02d:%02d", range->select_relative_date_r.year,
+    dt_util_str_cat(&txt, "+%04d:%02d:%02d %02d:%02d:%02d", range->select_relative_date_r.year,
                           range->select_relative_date_r.month, range->select_relative_date_r.day,
                           range->select_relative_date_r.hour, range->select_relative_date_r.minute,
                           range->select_relative_date_r.second);
   else if(range->bounds & DT_RANGE_BOUND_MAX_NOW)
-    txt = dt_util_dstrcat(txt, _("now"));
+    dt_util_str_cat(&txt, _("now"));
   else
-    txt = dt_util_dstrcat(txt, "%s", range->print(range->select_max_r, TRUE));
+    dt_util_str_cat(&txt, "%s", range->print(range->select_max_r, TRUE));
 
   return txt;
 }

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -176,12 +176,12 @@ static void _image_update_group_tooltip(dt_thumbnail_t *thumb)
     if(id != thumb->groupid)
     {
       if(id == thumb->imgid)
-        tt = dt_util_dstrcat(tt, "\n\u2022 %s", _("current"));
+        dt_util_str_cat(&tt, "\n\u2022 %s", _("current"));
       else
       {
-        tt = dt_util_dstrcat(tt, "\n\u2022 %s", sqlite3_column_text(stmt, 2));
+        dt_util_str_cat(&tt, "\n\u2022 %s", sqlite3_column_text(stmt, 2));
         if(v > 0)
-          tt = dt_util_dstrcat(tt, " v%d", v);
+          dt_util_str_cat(&tt, " v%d", v);
       }
     }
   }

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1497,24 +1497,24 @@ static void _thumbs_ask_for_discard(dt_thumbtable_t *table)
       g_strdup(_("you have changed the settings related to"
                  " how thumbnails are generated.\n"));
     if(max_level >= DT_MIPMAP_8 && min_level == DT_MIPMAP_0)
-      txt = dt_util_dstrcat(txt, _("all cached thumbnails need to be invalidated.\n\n"));
+      dt_util_str_cat(&txt, _("all cached thumbnails need to be invalidated.\n\n"));
     else if(max_level >= DT_MIPMAP_8)
-      txt = dt_util_dstrcat
-        (txt,
+      dt_util_str_cat
+        (&txt,
          _("cached thumbnails starting from level %d need to be invalidated.\n\n"),
          min_level);
     else if(min_level == DT_MIPMAP_0)
-      txt = dt_util_dstrcat
-        (txt,
+      dt_util_str_cat
+        (&txt,
          _("cached thumbnails below level %d need to be invalidated.\n\n"),
          max_level);
     else
-      txt = dt_util_dstrcat
-        (txt,
+      dt_util_str_cat
+        (&txt,
          _("cached thumbnails between level %d and %d need to be invalidated.\n\n"),
          min_level, max_level);
 
-    txt = dt_util_dstrcat(txt, _("do you want to do that now?"));
+    dt_util_str_cat(&txt, _("do you want to do that now?"));
 
     if(dt_gui_show_yes_no_dialog(_("cached thumbnails invalidation"),
                                  "%s", txt))

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -628,7 +628,7 @@ static gchar *_shortcut_key_move_name(dt_input_device_t id,
         gchar *key_name = gtk_accelerator_get_label(key_or_move, 0);
         post_name = g_utf8_strdown(key_name, -1);
         if(strlen(post_name) == 1 && _is_kp_key(key_or_move))
-          post_name = dt_util_dstrcat(post_name, " %s", _("(keypad)"));
+          dt_util_str_cat(&post_name, " %s", _("(keypad)"));
         g_free(key_name);
       }
       else
@@ -1082,7 +1082,7 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
   else
   {
     if(g_object_get_data(G_OBJECT(widget), "scroll-resize-tooltip"))
-      original_markup = dt_util_dstrcat(original_markup, "%s%s",
+      dt_util_str_cat(&original_markup, "%s%s",
                                         original_markup ? "\n" : "", _("shift+alt+scroll to change height"));
     action = dt_action_widget(widget);
     if(!action)
@@ -1119,8 +1119,8 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
       if(dt_bauhaus_slider_get_soft_min(widget) != hard_min ||
          dt_bauhaus_slider_get_soft_max(widget) != hard_max)
       {
-        original_markup = dt_util_dstrcat
-          (original_markup,
+        dt_util_str_cat
+          (&original_markup,
            _("%sright-click to type a specific value between <b>%s</b> and <b>%s</b>"
              "\nor hold ctrl+shift while dragging to ignore soft limits."),
            original_markup ? "\n\n" : "",
@@ -1166,9 +1166,9 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
       gchar *sc_escaped = g_markup_escape_text(_shortcut_description(s), -1);
       const int components = (show_element > 0 || s->element != darktable.control->element) ? 1 : 0;
       gchar *ac_escaped = g_markup_escape_text(_action_description(s, components), -1);
-      description = dt_util_dstrcat(description, "%s<b><big>%s</big></b><i>%s</i>",
-                                                 description ? "\n" : "",
-                                                 sc_escaped, ac_escaped);
+      dt_util_str_cat(&description, "%s<b><big>%s</big></b><i>%s</i>",
+                                    description ? "\n" : "",
+                                    sc_escaped, ac_escaped);
       g_free(sc_escaped);
       g_free(ac_escaped);
     }
@@ -1186,7 +1186,7 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
     {
       gchar *lua_escaped = g_markup_printf_escaped("\n\nLua: <tt>%s</tt>%s %s", lua_command,
                                     show_element == 1 ? _("ctrl+v") : _("right long click") , _("to copy Lua command"));
-      markup_text = dt_util_dstrcat(markup_text, "%s", lua_escaped);
+      dt_util_str_cat(&markup_text, "%s", lua_escaped);
       g_free(lua_escaped);
       g_free(lua_command);
     }
@@ -1195,8 +1195,8 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
 
   if(description || original_markup || markup_text)
   {
-    if(original_markup) markup_text = dt_util_dstrcat(markup_text, markup_text ? "\n\n%s" : "%s", original_markup);
-    if(description    ) markup_text = dt_util_dstrcat(markup_text, markup_text ? "\n\n%s" : "%s", description);
+    if(original_markup) dt_util_str_cat(&markup_text, markup_text ? "\n\n%s" : "%s", original_markup);
+    if(description    ) dt_util_str_cat(&markup_text, markup_text ? "\n\n%s" : "%s", description);
 
     GtkWidget *label = gtk_label_new(NULL);
     gtk_label_set_markup(GTK_LABEL(label), markup_text);
@@ -3520,7 +3520,7 @@ gboolean dt_action_widget_invisible(GtkWidget *w)
 }
 
 #define ADD_EXPLANATION(cause, effect, extra, ...) if(*fb_log) \
-      *fb_log = dt_util_dstrcat(*fb_log, "\n%s \u2192 %s" extra, cause, effect, ##__VA_ARGS__)
+      dt_util_str_cat(&*fb_log, "\n%s \u2192 %s" extra, cause, effect, ##__VA_ARGS__)
 
 static gboolean _shortcut_closest_match(GSequenceIter **current,
                                         dt_shortcut_t *s,

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -270,7 +270,8 @@ static gchar *_panels_get_panel_path(dt_ui_panel_t panel,
 {
   gchar *v = _panels_get_view_path("");
   if(!v) return NULL;
-  return dt_util_dstrcat(v, "%s%s", _ui_panel_config_names[panel], suffix);
+  dt_util_str_cat(&v, "%s%s", _ui_panel_config_names[panel], suffix);
+  return v;
 }
 
 static gboolean _panel_is_visible(dt_ui_panel_t panel)
@@ -3018,12 +3019,12 @@ void dt_gui_show_help(GtkWidget *widget)
     // in case of a standard release, append the dt version to the url
     if(dt_is_dev_version())
     {
-      base_url = dt_util_dstrcat(base_url, "development/");
+      dt_util_str_cat(&base_url, "development/");
     }
     else
     {
       char *ver = dt_version_major_minor();
-      base_url = dt_util_dstrcat(base_url, "%s/", ver);
+      dt_util_str_cat(&base_url, "%s/", ver);
       g_free(ver);
     }
 

--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -99,9 +99,9 @@ static gchar *_conf_get_path(gchar *module_name, gchar *property_1, gchar *prope
   }
 
   if(property_2)
-    return dt_util_dstrcat(NULL, "guides/%s/%s%s/%s/%s", cv->module_name, lay, module_name, property_1, property_2);
+    return g_strdup_printf("guides/%s/%s%s/%s/%s", cv->module_name, lay, module_name, property_1, property_2);
   else
-    return dt_util_dstrcat(NULL, "guides/%s/%s%s/%s", cv->module_name, lay, module_name, property_1);
+    return g_strdup_printf("guides/%s/%s%s/%s", cv->module_name, lay, module_name, property_1);
 }
 
 static dt_guides_t *_conf_get_guide(gchar *module_name)

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -316,7 +316,7 @@ static void _import_tags_presets_update(dt_import_metadata_t *metadata)
         {
           const guint tagid = strtoul(*entry, NULL, 0);
           char *tag = dt_tag_get_name(tagid);
-          tags = dt_util_dstrcat(tags, "%s,", tag);
+          dt_util_str_cat(&tags, "%s,", tag);
           g_free(tag);
           entry++;
         }

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1346,7 +1346,7 @@ static gboolean _menuitem_manage_quick_presets_traverse(GtkTreeModel *model,
 
   if(active && preset && iop_name)
   {
-    *txt = dt_util_dstrcat(*txt, "ꬹ%s|%sꬹ", iop_name, preset);
+    dt_util_str_cat(&*txt, "ꬹ%s|%sꬹ", iop_name, preset);
   }
   g_free(iop_name);
   g_free(preset);
@@ -1568,7 +1568,7 @@ void dt_gui_favorite_presets_menu_show()
           gchar *key = g_strdup_printf("plugins/darkroom/%s/favorite", iop->so->op);
           const gboolean fav = dt_conf_get_bool(key);
           g_free(key);
-          if(fav) config = dt_util_dstrcat(config, "ꬹ%s|%sꬹ", iop->so->op, name);
+          if(fav) dt_util_str_cat(&config, "ꬹ%s|%sꬹ", iop->so->op, name);
         }
 
         // check that this preset is in the config list

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -329,8 +329,7 @@ int store(dt_imageio_module_storage_t *self,
   char input_dir[PATH_MAX] = { 0 };
   char pattern[DT_MAX_PATH_FOR_PARAMS];
   g_strlcpy(pattern, d->filename, sizeof(pattern));
-  gboolean from_cache = FALSE;
-  dt_image_full_path(imgid, input_dir, sizeof(input_dir), &from_cache);
+  dt_image_full_path(imgid, input_dir, sizeof(input_dir), NULL);
   // set variable values to expand them afterwards in darktable variables
   dt_variables_set_max_width_height(d->vp, fdata->max_width, fdata->max_height);
   dt_variables_set_upscale(d->vp, upscale);

--- a/src/imageio/storage/email.c
+++ b/src/imageio/storage/email.c
@@ -159,8 +159,7 @@ int store(dt_imageio_module_storage_t *self,
   dt_loc_get_tmp_dir(tmpdir, sizeof(tmpdir));
 
   char dirname[PATH_MAX] = { 0 };
-  gboolean from_cache = FALSE;
-  dt_image_full_path(imgid, dirname, sizeof(dirname), &from_cache);
+  dt_image_full_path(imgid, dirname, sizeof(dirname), NULL);
   gchar *filename = g_path_get_basename(dirname);
 
   g_strlcpy(dirname, filename, sizeof(dirname));

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -272,8 +272,7 @@ int store(dt_imageio_module_storage_t *self,
 
   char filename[PATH_MAX] = { 0 };
   char dirname[PATH_MAX] = { 0 };
-  gboolean from_cache = FALSE;
-  dt_image_full_path(imgid, dirname, sizeof(dirname), &from_cache);
+  dt_image_full_path(imgid, dirname, sizeof(dirname), NULL);
 
   char tmp_dir[PATH_MAX] = { 0 };
 

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -242,8 +242,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
 
   char filename[PATH_MAX] = { 0 };
   char dirname[PATH_MAX] = { 0 };
-  gboolean from_cache = FALSE;
-  dt_image_full_path(imgid, dirname, sizeof(dirname), &from_cache);
+  dt_image_full_path(imgid, dirname, sizeof(dirname), NULL);
   // we're potentially called in parallel. have sequence number synchronized:
   dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
   {

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -976,8 +976,7 @@ static void _drag_and_drop_received(GtkWidget *widget,
 
         dt_overlay_record(self->dev->image_storage.id, p->imgid);
 
-        gboolean from_cache = FALSE;
-        dt_image_full_path(p->imgid, p->filename, sizeof(p->filename), &from_cache);
+        dt_image_full_path(p->imgid, p->filename, sizeof(p->filename), NULL);
 
         dt_dev_add_history_item(darktable.develop, self, TRUE);
 

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -555,9 +555,8 @@ static gchar *_watermark_get_svgdoc(dt_iop_module_t *self, dt_iop_watermark_data
     const int32_t flags = dt_lib_export_metadata_get_conf_flags();
     dt_variables_params_t *params;
     dt_variables_params_init(&params);
-    gboolean from_cache = FALSE;
     char image_path[PATH_MAX] = { 0 };
-    dt_image_full_path(image->id, image_path, sizeof(image_path), &from_cache);
+    dt_image_full_path(image->id, image_path, sizeof(image_path), NULL);
     params->filename = image_path;
     params->jobcode = "infos";
     params->use_html_newline = TRUE;

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1429,8 +1429,8 @@ static void _tree_view(dt_lib_collect_rule_t *dr)
           // clang-format on
 
         // clang-format off
-        query = dt_util_dstrcat
-          (query, " UNION ALL "
+        dt_util_str_cat
+          (&query, " UNION ALL "
            "SELECT '%s' AS name, 0 as id, COUNT(*) AS count "
            "FROM main.images AS mi "
            "WHERE mi.id NOT IN"
@@ -1675,13 +1675,13 @@ static void _tree_view(dt_lib_collect_rule_t *dr)
           if(property == DT_COLLECTION_PROP_FOLDERS) pth = g_strdup("/");
 #endif
           for(int i = 0; i < common_length; i++)
-            pth = dt_util_dstrcat(pth, format_separator, tokens[i]);
+            dt_util_str_cat(&pth, format_separator, tokens[i]);
 
           for(char **token = &tokens[common_length]; *token; token++)
           {
             GtkTreeIter iter;
 
-            pth = dt_util_dstrcat(pth, format_separator, *token);
+            dt_util_str_cat(&pth, format_separator, *token);
             if(_is_time_property(property) && !*(token + 1)) pth[10] = ' ';
 
             gchar *pth2 = g_strdup(pth);
@@ -2121,10 +2121,10 @@ static void _list_view(dt_lib_collect_rule_t *dr)
           char *orders = NULL;
           for(int i = 0; i < DT_IOP_ORDER_LAST; i++)
           {
-            orders = dt_util_dstrcat(orders, "WHEN mo.version = %d THEN '%s' ",
+            dt_util_str_cat(&orders, "WHEN mo.version = %d THEN '%s' ",
                                      i, _(dt_iop_order_string(i)));
           }
-          orders = dt_util_dstrcat(orders, "ELSE '%s' ", _("none"));
+          dt_util_str_cat(&orders, "ELSE '%s' ", _("none"));
           // clang-format off
           snprintf(query, sizeof(query),
                    "SELECT CASE %s END as ver, 1, COUNT(*) AS count"

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -466,7 +466,7 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
       gtk_tree_model_get(GTK_TREE_MODEL(d->liststore), &iter, DT_LIB_EXPORT_METADATA_COL_XMP, &tagname,
           DT_LIB_EXPORT_METADATA_COL_FORMULA, &formula, -1);
       // metadata presets are stored into a single string with '\1' as a separator
-      newlist = dt_util_dstrcat(newlist,"\1%s\1%s", tagname, formula);
+      dt_util_str_cat(&newlist,"\1%s\1%s", tagname, formula);
       g_free(tagname);
       g_free(formula);
       valid = gtk_tree_model_iter_next (GTK_TREE_MODEL(d->liststore), &iter);

--- a/src/libs/filters/colors.c
+++ b/src/libs/filters/colors.c
@@ -149,7 +149,7 @@ static gchar *_colors_pretty_print(const gchar *raw_txt)
         col = g_strdup(_("P"));
         break;
     }
-    txt = dt_util_dstrcat(txt, "%s%s%s%s", (i == 0) ? "" : " ", (incl) ? "" : "<s>", col, (incl) ? "" : "</s>");
+    dt_util_str_cat(&txt, "%s%s%s%s", (i == 0) ? "" : " ", (incl) ? "" : "<s>", col, (incl) ? "" : "</s>");
     g_free(col);
   }
   if(nb == 0)

--- a/src/libs/filters/filename.c
+++ b/src/libs/filters/filename.c
@@ -313,7 +313,7 @@ static void _filename_tree_selection_change(GtkTreeSelection *sel, _widgets_file
     {
       gchar *val = NULL;
       gtk_tree_model_get(model, &iter, TREE_COL_PATH, &val, -1);
-      if(val) txt = dt_util_dstrcat(txt, "%s%s", (txt == NULL) ? "" : ",", val);
+      if(val) dt_util_str_cat(&txt, "%s%s", (txt == NULL) ? "" : ",", val);
     }
   }
   g_list_free_full(list, (GDestroyNotify)gtk_tree_path_free);

--- a/src/libs/filters/focal.c
+++ b/src/libs/filters/focal.c
@@ -71,7 +71,7 @@ static gchar *_focal_print_func(const double value, const gboolean detailled)
 
   if(detailled)
   {
-    txt = dt_util_dstrcat(txt, " %s", _("mm"));
+    dt_util_str_cat(&txt, " %s", _("mm"));
   }
   return txt;
 }

--- a/src/libs/filters/misc.c
+++ b/src/libs/filters/misc.c
@@ -340,7 +340,7 @@ static void _misc_tree_selection_changed(GtkTreeSelection *sel,
     {
       gchar *val = NULL;
       gtk_tree_model_get(model, &iter, TREE_COL_PATH, &val, -1);
-      if(val) txt = dt_util_dstrcat(txt, "%s%s", (txt == NULL) ? "" : ",", val);
+      if(val) dt_util_str_cat(&txt, "%s%s", (txt == NULL) ? "" : ",", val);
     }
   }
   g_list_free_full(list, (GDestroyNotify)gtk_tree_path_free);

--- a/src/libs/filters/ratio.c
+++ b/src/libs/filters/ratio.c
@@ -117,11 +117,11 @@ static gchar *_ratio_print_func(const double value, const gboolean detailled)
   if(detailled)
   {
     if(value < 1.0)
-      return dt_util_dstrcat(txt, " %s", _("portrait"));
+      dt_util_str_cat(&txt, " %s", _("portrait"));
     else if(value > 1.0)
-      return dt_util_dstrcat(txt, " %s", _("landscape"));
+      dt_util_str_cat(&txt, " %s", _("landscape"));
     else if(value == 1.0)
-      return dt_util_dstrcat(txt, " %s", _("square"));
+      dt_util_str_cat(&txt, " %s", _("square"));
   }
   return txt;
 }

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1689,7 +1689,7 @@ static gboolean _drawable_motion_notify_callback(GtkWidget *widget,
       if(d->scope_type == DT_LIB_HISTOGRAM_SCOPE_VECTORSCOPE &&
               d->vectorscope_type == DT_LIB_HISTOGRAM_VECTORSCOPE_RYB &&
               d->harmony_guide.type != DT_COLOR_HARMONY_NONE)
-        tip = dt_util_dstrcat(tip, "\n%s\n%s\n%s\n%s",
+        dt_util_str_cat(&tip, "\n%s\n%s\n%s\n%s",
                               _("scroll to coarse-rotate"),
                               _("ctrl+scroll to fine rotate"),
                               _("shift+scroll to change width"),
@@ -1706,14 +1706,14 @@ static gboolean _drawable_motion_notify_callback(GtkWidget *widget,
                      && d->scope_orient == DT_LIB_HISTOGRAM_ORIENT_VERT))))
       {
         d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT;
-        tip = dt_util_dstrcat(tip, "\n%s\n%s",
+        dt_util_str_cat(&tip, "\n%s\n%s",
                               _("drag to change black point"),
                               _("double-click resets"));
       }
       else
       {
         d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE;
-        tip = dt_util_dstrcat(tip, "\n%s\n%s",
+        dt_util_str_cat(&tip, "\n%s\n%s",
                               _("drag to change exposure"),
                               _("double-click resets"));
       }

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -2288,7 +2288,7 @@ static void _import_from_dialog_run(dt_lib_module_t* self)
       if(d->import_case == DT_IMPORT_INPLACE)
       {
         if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->recursive)))
-          folder = dt_util_dstrcat(folder, "%%");
+          dt_util_str_cat(&folder, "%%");
         _import_set_collection(folder);
         const dt_imgid_t imgid = dt_conf_get_int("ui_last/import_last_image");
         if(unique && dt_is_valid_imgid(imgid))
@@ -2572,18 +2572,18 @@ static char *_get_current_configuration(dt_lib_module_t *self)
   {
     if(_pref[i].type == DT_BOOL)
     {
-      pref = dt_util_dstrcat(pref, "%s=%d,", _pref[i].name,
+      dt_util_str_cat(&pref, "%s=%d,", _pref[i].name,
                              dt_conf_get_bool(_pref[i].key) ? 1 : 0);
     }
     else if(_pref[i].type == DT_INT)
     {
-      pref = dt_util_dstrcat(pref, "%s=%d,", _pref[i].name,
+      dt_util_str_cat(&pref, "%s=%d,", _pref[i].name,
                              dt_conf_get_int(_pref[i].key));
     }
     else if(_pref[i].type == DT_STRING)
     {
       const char *s = dt_conf_get_string_const(_pref[i].key);
-      pref = dt_util_dstrcat(pref, "%s=%s,", _pref[i].name, s);
+      dt_util_str_cat(&pref, "%s=%s,", _pref[i].name, s);
     }
   }
 
@@ -2599,7 +2599,7 @@ static char *_get_current_configuration(dt_lib_module_t *self)
 
       setting = g_strdup_printf("ui_last/import_last_%s", metadata_name);
       const char *metadata_value = dt_conf_get_string_const(setting);
-      pref = dt_util_dstrcat(pref, "%s=%d%s,", metadata_name,
+      dt_util_str_cat(&pref, "%s=%d%s,", metadata_name,
                              imported ? 1 : 0, metadata_value);
       g_free(setting);
     }
@@ -2607,7 +2607,7 @@ static char *_get_current_configuration(dt_lib_module_t *self)
   // must be the last (comma separated list)
   const gboolean imported = dt_conf_get_bool("ui_last/import_last_tags_imported");
   const char *tags_value = dt_conf_get_string_const("ui_last/import_last_tags");
-  pref = dt_util_dstrcat(pref, "%s=%d%s,", "tags", imported ? 1 : 0, tags_value);
+  dt_util_str_cat(&pref, "%s=%d%s,", "tags", imported ? 1 : 0, tags_value);
   if(pref && *pref)
     pref[strlen(pref) - 1] = '\0';
 
@@ -2677,7 +2677,7 @@ static void _apply_preferences(const char *pref,
       for(GList *iter2 = g_list_next(iter); iter2; iter2 = g_list_next(iter2))
       {
         if(strlen((char *)iter2->data))
-          tags = dt_util_dstrcat(tags, ",%s", (char *)iter2->data);
+          dt_util_str_cat(&tags, ",%s", (char *)iter2->data);
       }
       dt_conf_set_string("ui_last/import_last_tags", tags);
       g_free(tags);

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -166,11 +166,11 @@ static void _locations_tree_update(dt_lib_module_t *self, const guint locid)
         // insert everything from tokens past the common part
         char *pth = NULL;
         for(int i = 0; i < common_length; i++)
-          pth = dt_util_dstrcat(pth, "%s|", tokens[i]);
+          dt_util_str_cat(&pth, "%s|", tokens[i]);
 
         for(char **token = &tokens[common_length]; *token; token++)
         {
-          pth = dt_util_dstrcat(pth, "%s|", *token);
+          dt_util_str_cat(&pth, "%s|", *token);
           gchar *pth2 = g_strdup(pth);
           pth2[strlen(pth2) - 1] = '\0';
           gtk_tree_store_insert(GTK_TREE_STORE(model), &iter, common_length > 0 ? &parent : NULL, -1);
@@ -283,7 +283,7 @@ static void _new_button_clicked(GtkButton *button, dt_lib_module_t *self)
   name = path ? g_strconcat(path, "|", NULL) : g_strdup("");
   const int base_len = strlen(name);
   int i = 1;
-  name = dt_util_dstrcat(name, "%s", _("new location"));
+  dt_util_str_cat(&name, "%s", _("new location"));
   char *new_name = g_strdup(name);
   while(dt_map_location_name_exists(new_name))
   {

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -967,10 +967,10 @@ void gui_update(dt_lib_module_t *self)
               // tags - just keywords
               length = length + strlen(tagname) + 2u;
               if(length < 45u)
-                tagstring = dt_util_dstrcat(tagstring, "%s, ", tagname);
+                dt_util_str_cat(&tagstring, "%s, ", tagname);
               else
               {
-                tagstring = dt_util_dstrcat(tagstring, "\n%s, ", tagname);
+                dt_util_str_cat(&tagstring, "\n%s, ", tagname);
                 length = strlen(tagname) + 2u;
               }
             }
@@ -984,11 +984,11 @@ void gui_update(dt_lib_module_t *self)
                 catend[0] = '\0';
                 char *catstart = g_strrstr(category, "|");
                 catstart = catstart ? catstart + 1 : category;
-                categoriesstring = dt_util_dstrcat(categoriesstring, categoriesstring ? "\n%s: %s " : "%s: %s ",
+                dt_util_str_cat(&categoriesstring, categoriesstring ? "\n%s: %s " : "%s: %s ",
                                                    catstart, ((dt_tag_t *)taglist->data)->leave);
               }
               else
-                categoriesstring = dt_util_dstrcat(categoriesstring, categoriesstring ? "\n%s" : "%s",
+                dt_util_str_cat(&categoriesstring, categoriesstring ? "\n%s" : "%s",
                                                    ((dt_tag_t *)taglist->data)->leave);
               g_free(category);
             }
@@ -1114,7 +1114,7 @@ static char *_get_current_configuration(dt_lib_module_t *self)
   {
     dt_lib_metadata_info_t *m = (dt_lib_metadata_info_t *)meta->data;
     if(_is_metadata_ui(m->index))
-      pref = dt_util_dstrcat(pref, "%s%s,", m->visible ? "" : "|", m->name);
+      dt_util_str_cat(&pref, "%s%s,", m->visible ? "" : "|", m->name);
   }
   if(pref)
   {

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -687,8 +687,7 @@ void gui_update(dt_lib_module_t *self)
 
       case md_internal_fullpath:
       {
-        gboolean from_cache = FALSE;
-        dt_image_full_path(img->id, text, sizeof(text), &from_cache);
+        dt_image_full_path(img->id, text, sizeof(text), NULL);
         _metadata_update_value(md_internal_fullpath, text, self);
       }
       break;

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1096,19 +1096,19 @@ static dt_lib_modulegroup_iop_visibility_type_t _preset_retrieve_old_search_pref
   if(strcmp(show_text_entry, "show search text") == 0)
   {
     // we only show the search box. no groups
-    *ret = dt_util_dstrcat(*ret, "1ꬹ1");
+    dt_util_str_cat(&*ret, "1ꬹ1");
     val = DT_MODULEGROUP_SEARCH_IOP_TEXT_VISIBLE;
   }
   else if(strcmp(show_text_entry, "show groups") == 0)
   {
     // we don't show the search box
-    *ret = dt_util_dstrcat(*ret, "0");
+    dt_util_str_cat(&*ret, "0");
     val = DT_MODULEGROUP_SEARCH_IOP_GROUPS_VISIBLE;
   }
   else
   {
     // we show both
-    *ret = dt_util_dstrcat(*ret, "1");
+    dt_util_str_cat(&*ret, "1");
     val = DT_MODULEGROUP_SEARCH_IOP_TEXT_GROUPS_VISIBLE;
   }
   return val;
@@ -1136,19 +1136,19 @@ static gchar *_preset_retrieve_old_layout_updated()
     // group name and icon
     if(i == 0)
     {
-      ret = dt_util_dstrcat(
-          ret, "1|0ꬹ1|||%s",
+      dt_util_str_cat(
+          &ret, "1|0ꬹ1|||%s",
           "exposure/exposure|temperature/temperature|temperature/tint|colorbalancergb/contrast"
           "|colorbalancergb/global vibrance|colorbalancergb/global chroma|colorbalancergb/global saturation"
           "|ashift/rotation|denoiseprofile|lens|bilat");
-      ret = dt_util_dstrcat(ret, "ꬹfavorites|favorites|");
+      dt_util_str_cat(&ret, "ꬹfavorites|favorites|");
     }
     else if(i == 1)
-      ret = dt_util_dstrcat(ret, "ꬹtechnical|technical|");
+      dt_util_str_cat(&ret, "ꬹtechnical|technical|");
     else if(i == 2)
-      ret = dt_util_dstrcat(ret, "ꬹgrading|grading|");
+      dt_util_str_cat(&ret, "ꬹgrading|grading|");
     else if(i == 3)
-      ret = dt_util_dstrcat(ret, "ꬹeffects|effect|");
+      dt_util_str_cat(&ret, "ꬹeffects|effect|");
 
     // list of modules
     for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
@@ -1169,7 +1169,7 @@ static gchar *_preset_retrieve_old_layout_updated()
         if((i == 0 && fav && visi) || (i == 1 && (group & IOP_GROUP_TECHNICAL) && visi)
            || (i == 2 && (group & IOP_GROUP_GRADING) && visi) || (i == 3 && (group & IOP_GROUP_EFFECTS) && visi))
         {
-          ret = dt_util_dstrcat(ret, "|%s", module->op);
+          dt_util_str_cat(&ret, "|%s", module->op);
         }
       }
     }
@@ -1191,23 +1191,23 @@ static gchar *_preset_retrieve_old_layout(const char *list, const char *list_fav
     if(i == 0)
     {
       // we don't have to care about "modern" workflow for temperature as it's more recent than this layout
-      ret = dt_util_dstrcat(
-          ret, "1|0ꬹ1|||%s",
+      dt_util_str_cat(
+          &ret, "1|0ꬹ1|||%s",
           "exposure/exposure|temperature/temperature|temperature/tint|colorbalancergb/contrast"
           "|colorbalancergb/global vibrance|colorbalancergb/global chroma|colorbalancergb/global saturation"
           "|ashift/rotation|denoiseprofile|lens|bilat");
-      ret = dt_util_dstrcat(ret, "ꬹfavorites|favorites|");
+      dt_util_str_cat(&ret, "ꬹfavorites|favorites|");
     }
     else if(i == 1)
-      ret = dt_util_dstrcat(ret, "ꬹbase|basic|");
+      dt_util_str_cat(&ret, "ꬹbase|basic|");
     else if(i == 2)
-      ret = dt_util_dstrcat(ret, "ꬹtone|tone|");
+      dt_util_str_cat(&ret, "ꬹtone|tone|");
     else if(i == 3)
-      ret = dt_util_dstrcat(ret, "ꬹcolor|color|");
+      dt_util_str_cat(&ret, "ꬹcolor|color|");
     else if(i == 4)
-      ret = dt_util_dstrcat(ret, "ꬹcorrect|correct|");
+      dt_util_str_cat(&ret, "ꬹcorrect|correct|");
     else if(i == 5)
-      ret = dt_util_dstrcat(ret, "ꬹeffect|effect|");
+      dt_util_str_cat(&ret, "ꬹeffect|effect|");
 
     // list of modules
     for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
@@ -1265,7 +1265,7 @@ static gchar *_preset_retrieve_old_layout(const char *list, const char *list_fav
 
         if((i == 0 && fav && visi) || (i == group && visi))
         {
-          ret = dt_util_dstrcat(ret, "|%s", module->op);
+          dt_util_str_cat(&ret, "|%s", module->op);
         }
 
         g_free(search);
@@ -1303,16 +1303,16 @@ static void _preset_retrieve_old_presets(dt_lib_module_t *self)
       dt_iop_module_state_t state = p[pos + op_len + 1];
 
       if(state == IOP_STATE_ACTIVE)
-        list = dt_util_dstrcat(list, "|%s", op);
+        dt_util_str_cat(&list, "|%s", op);
       else if(state == IOP_STATE_FAVORITE)
       {
-        fav = dt_util_dstrcat(fav, "|%s", op);
-        list = dt_util_dstrcat(list, "|%s", op);
+        dt_util_str_cat(&fav, "|%s", op);
+        dt_util_str_cat(&list, "|%s", op);
       }
       pos += op_len + 2;
     }
-    list = dt_util_dstrcat(list, "|");
-    fav = dt_util_dstrcat(fav, "|");
+    dt_util_str_cat(&list, "|");
+    dt_util_str_cat(&fav, "|");
 
     gchar *tx = _preset_retrieve_old_layout(list, fav);
     dt_lib_presets_add(pname, self->plugin_name, self->version(), tx, strlen(tx), FALSE, 0);
@@ -1335,28 +1335,28 @@ static gchar *_preset_to_string(dt_lib_module_t *self, gboolean edition)
   gchar *res = NULL;
   const gboolean show_search = edition ? d->edit_show_search : d->show_search;
   const gboolean full_active = edition ? d->edit_full_active : d->full_active;
-  res = dt_util_dstrcat(res, "%d|%d", show_search ? 1 : 0, full_active ? 1 : 0);
+  dt_util_str_cat(&res, "%d|%d", show_search ? 1 : 0, full_active ? 1 : 0);
 
   const gboolean basics_show = edition ? d->edit_basics_show : d->basics_show;
   GList *basics = edition ? d->edit_basics : d->basics;
   GList *groups = edition ? d->edit_groups : d->groups;
 
   // basics widgets
-  res = dt_util_dstrcat(res, "ꬹ%d||", basics_show ? 1 : 0);
+  dt_util_str_cat(&res, "ꬹ%d||", basics_show ? 1 : 0);
   for(const GList *l = basics; l; l = g_list_next(l))
   {
     dt_lib_modulegroups_basic_item_t *item = (dt_lib_modulegroups_basic_item_t *)l->data;
-    res = dt_util_dstrcat(res, "|%s", item->id);
+    dt_util_str_cat(&res, "|%s", item->id);
   }
 
   for(const GList *l = groups; l; l = g_list_next(l))
   {
     dt_lib_modulegroups_group_t *g = (dt_lib_modulegroups_group_t *)l->data;
-    res = dt_util_dstrcat(res, "ꬹ%s|%s|", g->name, g->icon);
+    dt_util_str_cat(&res, "ꬹ%s|%s|", g->name, g->icon);
     for(const GList *ll = g->modules; ll; ll = g_list_next(ll))
     {
       gchar *m = (gchar *)ll->data;
-      res = dt_util_dstrcat(res, "|%s", m);
+      dt_util_str_cat(&res, "|%s", m);
     }
   }
 
@@ -1513,10 +1513,10 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
   }
 
 // start module group
-#define SMG(g,n) tx = dt_util_dstrcat(tx, "ꬹ%s|%s|", g, n)
+#define SMG(g,n) dt_util_str_cat(&tx, "ꬹ%s|%s|", g, n)
 
 // add module
-#define AM(n)    tx = dt_util_dstrcat(tx, "|%s", n)
+#define AM(n)    dt_util_str_cat(&tx, "|%s", n)
 
 void init_presets(dt_lib_module_t *self)
 {
@@ -2549,7 +2549,7 @@ static GtkWidget *_build_menu_from_actions(dt_action_t *actions,
         {
           gtk_check_menu_item_set_inconsistent(GTK_CHECK_MENU_ITEM(item), TRUE);
           gchar *toolmark = gtk_widget_get_tooltip_text(item);
-          toolmark = dt_util_dstrcat(toolmark, " <i>(%s)</i>", _("currently invisible"));
+          dt_util_str_cat(&toolmark, " <i>(%s)</i>", _("currently invisible"));
           gtk_widget_set_tooltip_markup(item, toolmark);
           if(item_top)
             gtk_widget_set_tooltip_markup(item_top, toolmark);

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -186,7 +186,7 @@ static gboolean _set_matching_tag_visibility(GtkTreeModel *model, GtkTreePath *p
     visible = TRUE;
   else
   {
-    if(synonyms && synonyms[0]) tagname = dt_util_dstrcat(tagname, ", %s", synonyms);
+    if(synonyms && synonyms[0]) dt_util_str_cat(&tagname, ", %s", synonyms);
     gchar *haystack = g_utf8_strdown(tagname, -1);
     gchar *needle = g_utf8_strdown(d->keyword, -1);
     visible = (g_strrstr(haystack, needle) != NULL);
@@ -441,11 +441,11 @@ static void _init_treeview(dt_lib_module_t *self, const int which)
           // insert everything from tokens past the common part
           char *pth = NULL;
           for(int i = 0; i < common_length; i++)
-            pth = dt_util_dstrcat(pth, "%s|", tokens[i]);
+            dt_util_str_cat(&pth, "%s|", tokens[i]);
 
           for(char **token = &tokens[common_length]; *token; token++)
           {
-            pth = dt_util_dstrcat(pth, "%s|", *token);
+            dt_util_str_cat(&pth, "%s|", *token);
             gchar *pth2 = g_strdup(pth);
             pth2[strlen(pth2) - 1] = '\0';
             gtk_tree_store_insert(GTK_TREE_STORE(store), &iter, common_length > 0 ? &parent : NULL, -1);
@@ -1005,7 +1005,7 @@ void *get_params(dt_lib_module_t *self, int *size)
   {
     for(GList *taglist = tags; taglist; taglist = g_list_next(taglist))
     {
-      params = dt_util_dstrcat(params, "%d,", ((dt_tag_t *)taglist->data)->id);
+      dt_util_str_cat(&params, "%d,", ((dt_tag_t *)taglist->data)->id);
     }
     dt_tag_free_result(&tags);
     if(params == NULL)
@@ -1750,7 +1750,7 @@ static void _pop_menu_dictionary_create_tag(GtkWidget *menuitem, dt_lib_module_t
     if(!root)
     {
       new_tagname = g_strdup(path);
-      new_tagname = dt_util_dstrcat(new_tagname, "|%s", newtag);
+      dt_util_str_cat(&new_tagname, "|%s", newtag);
     }
     else new_tagname = g_strdup(newtag);
 
@@ -2509,8 +2509,8 @@ static gboolean _row_tooltip_setup(GtkWidget *treeview, gint x, gint y, gboolean
         if((flags & DT_TF_PRIVATE) || (synonyms && synonyms[0]))
         {
           gchar *text = g_strdup_printf(_("%s"), tagname);
-          text = dt_util_dstrcat(text, " %s\n", (flags & DT_TF_PRIVATE) ? _("(private)") : "");
-          text = dt_util_dstrcat(text, "synonyms: %s", (synonyms && synonyms[0]) ? synonyms : " - ");
+          dt_util_str_cat(&text, " %s\n", (flags & DT_TF_PRIVATE) ? _("(private)") : "");
+          dt_util_str_cat(&text, "synonyms: %s", (synonyms && synonyms[0]) ? synonyms : " - ");
           gtk_tooltip_set_text(tooltip, text);
           g_free(text);
           res = TRUE;
@@ -2958,7 +2958,7 @@ static void _event_dnd_received(GtkWidget *widget, GdkDragContext *context, gint
       const gboolean root = (name && name[0] == '\0');
       char *leave = g_strrstr(d->drag.tagname, "|");
       if(leave) leave++;
-      name = dt_util_dstrcat(name, "%s%s", root ? "" : "|", leave ? leave : d->drag.tagname);
+      dt_util_str_cat(&name, "%s%s", root ? "" : "|", leave ? leave : d->drag.tagname);
       _apply_rename_path(NULL, d->drag.tagname, name, self);
 
       g_free(name);

--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -424,8 +424,7 @@ static int image_tostring(lua_State *L)
 {
   const dt_image_t *my_image = checkreadimage(L, -1);
   char image_name[PATH_MAX] = { 0 };
-  gboolean from_cache = FALSE;
-  dt_image_full_path(my_image->id, image_name, sizeof(image_name), &from_cache);
+  dt_image_full_path(my_image->id, image_name, sizeof(image_name), NULL);
   dt_image_path_append_version(my_image->id, image_name, sizeof(image_name));
   lua_pushstring(L, image_name);
   releasereadimage(L, my_image);

--- a/src/lua/luastorage.c
+++ b/src/lua/luastorage.c
@@ -100,11 +100,10 @@ static int store_wrapper(struct dt_imageio_module_storage_t *self,
 
   /* construct a temporary file name */
   char tmpdir[PATH_MAX] = { 0 };
-  gboolean from_cache = FALSE;
   dt_loc_get_tmp_dir(tmpdir, sizeof(tmpdir));
 
   char dirname[PATH_MAX] = { 0 };
-  dt_image_full_path(imgid, dirname, sizeof(dirname), &from_cache);
+  dt_image_full_path(imgid, dirname, sizeof(dirname), NULL);
   dt_image_path_append_version(imgid, dirname, sizeof(dirname));
   gchar *filename = g_path_get_basename(dirname);
   gchar *end = g_strrstr(filename, ".") + 1;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1354,44 +1354,44 @@ static gchar *_mouse_action_get_string(dt_mouse_action_t *ma)
 {
   gchar *atxt = NULL;
   if(ma->mods & GDK_SHIFT_MASK  )
-    atxt = dt_util_dstrcat(atxt, "%s+", _("shift"));
+    dt_util_str_cat(&atxt, "%s+", _("shift"));
   if(ma->mods & GDK_CONTROL_MASK)
-    atxt = dt_util_dstrcat(atxt, "%s+", _("ctrl"));
+    dt_util_str_cat(&atxt, "%s+", _("ctrl"));
   if(ma->mods & GDK_MOD1_MASK   )
 #ifdef __APPLE__
-    atxt = dt_util_dstrcat(atxt, "%s+", _("option"));
+    dt_util_str_cat(&atxt, "%s+", _("option"));
 #else
-    atxt = dt_util_dstrcat(atxt, "%s+", _("alt"));
+    dt_util_str_cat(&atxt, "%s+", _("alt"));
 #endif
 
   switch(ma->action)
   {
     case DT_MOUSE_ACTION_LEFT:
-      atxt = dt_util_dstrcat(atxt, _("left click"));
+      dt_util_str_cat(&atxt, _("left click"));
       break;
     case DT_MOUSE_ACTION_RIGHT:
-      atxt = dt_util_dstrcat(atxt, _("right click"));
+      dt_util_str_cat(&atxt, _("right click"));
       break;
     case DT_MOUSE_ACTION_MIDDLE:
-      atxt = dt_util_dstrcat(atxt, _("middle click"));
+      dt_util_str_cat(&atxt, _("middle click"));
       break;
     case DT_MOUSE_ACTION_SCROLL:
-      atxt = dt_util_dstrcat(atxt, _("scroll"));
+      dt_util_str_cat(&atxt, _("scroll"));
       break;
     case DT_MOUSE_ACTION_DOUBLE_LEFT:
-      atxt = dt_util_dstrcat(atxt, _("left double-click"));
+      dt_util_str_cat(&atxt, _("left double-click"));
       break;
     case DT_MOUSE_ACTION_DOUBLE_RIGHT:
-      atxt = dt_util_dstrcat(atxt, _("right double-click"));
+      dt_util_str_cat(&atxt, _("right double-click"));
       break;
     case DT_MOUSE_ACTION_DRAG_DROP:
-      atxt = dt_util_dstrcat(atxt, _("drag and drop"));
+      dt_util_str_cat(&atxt, _("drag and drop"));
       break;
     case DT_MOUSE_ACTION_LEFT_DRAG:
-      atxt = dt_util_dstrcat(atxt, _("left click+drag"));
+      dt_util_str_cat(&atxt, _("left click+drag"));
       break;
     case DT_MOUSE_ACTION_RIGHT_DRAG:
-      atxt = dt_util_dstrcat(atxt, _("right click+drag"));
+      dt_util_str_cat(&atxt, _("right click+drag"));
       break;
   }
 


### PR DESCRIPTION
Allow overriding individual values within the xmp params blob by specifying them in human readable form in a companion sidecar file called `<image_file>.override`.

For example, when loading `D71_5191.NEF`, if a file `D71_5191.NEF.override` exists, any lines it contains are interpreted as
`<module>[,<instance name>]/<field>=<value>`
so one could force a non-default exposure setting with:
`exposure/exposure=2.0`

The module and field codes are the internal introspection ones, so may need to be looked up in the xmp or by switching to shortcut mapping mode and hovering over the widget associated with the field and noting the lua command details in the tooltip. Still, the field name might not work, especially in case of sections. `colorequal/saturation/red` is actually internally called `sat_red`. To find the real introspection names, one could read the source, but if a line in the `.override` file contains just a module name, all its manipulable fields are printed to the terminal (together with the valid range or available dropdown values).

Arrays (curves and for example the multiple tabs in `colormixerrgb`, but also strings), are not supported. You would see something like `red[0]` (so in theory you could override the first element, which is probably not that useful).

If multiple instances of the same module exist, the instance name should be specified, for example:
```
exposure,first/exposure=1.4
exposure,second/exposure=3.0
```
You cannot activate (or create a new instance of) a module this way; it already needs to be in the history (or in the default or an automatically applied style/preset). No range validation takes place, so it is probably very easy to trigger a crash. At least with `-d params` (or `--core -d params`) an out-of-bounds will be flagged.

@AxelG-DE