### PR TITLE
compile for macOS

### DIFF
--- a/DefineOptions.cmake
+++ b/DefineOptions.cmake
@@ -45,7 +45,7 @@ else ()
 endif ()
 
 if(APPLE)
-    option(USE_MAC_INTEGRATION "Enable macOS integration" ON)
+  option(USE_MAC_INTEGRATION "Enable macOS integration" OFF)
 else(APPLE)
     set(USE_MAC_INTEGRATION OFF)
 endif(APPLE)

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -56,7 +56,7 @@
 #ifdef MAC_INTEGRATION
 #include <gtkosxapplication.h>
 #endif
-#ifdef GDK_WINDOWING_QUARTZ
+#ifdef __APPLE__
 #include "osx/osx.h"
 #endif
 #ifdef _WIN32


### PR DESCRIPTION
Disable option USE_MAC_INTEGRATION which should no longer be needed with gtk4

Slightly simpler now :)